### PR TITLE
Fix push notifications with Progressier service worker

### DIFF
--- a/app/templates/notification_settings.html
+++ b/app/templates/notification_settings.html
@@ -94,7 +94,7 @@
       if (!("serviceWorker" in navigator)) {
         throw new Error("Service workers are not supported in this browser.");
       }
-      return navigator.serviceWorker.register("/qsl-digest-sw.js");
+      return navigator.serviceWorker.register("/qsl-digest-sw.js", { scope: "/notifications/" });
     }
 
     async function subscribePush() {


### PR DESCRIPTION
## Summary
- register qsl push service worker with scope `/notifications/` instead of `/`
- avoids root-scope conflict with Progressier service worker (`/progressier.js`)
- ensures browser push setup page can own its own subscription worker

## Validation
- `.venv/bin/pytest -q tests/test_digest_routes_api.py tests/test_digest_notifications.py`
- result: `8 passed`
