### PR TITLE
Fix disable push for legacy service worker subscriptions

### DIFF
--- a/app/templates/notification_settings.html
+++ b/app/templates/notification_settings.html
@@ -97,6 +97,21 @@
       return navigator.serviceWorker.register("/qsl-digest-sw.js", { scope: "/notifications/" });
     }
 
+    async function getAllLocalSubscriptions() {
+      if (!("serviceWorker" in navigator)) {
+        return [];
+      }
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      const result = [];
+      for (const registration of registrations) {
+        const subscription = await registration.pushManager.getSubscription();
+        if (subscription) {
+          result.push({ registration, subscription });
+        }
+      }
+      return result;
+    }
+
     async function subscribePush() {
       if (!publicVapidKey) {
         updateStatus("Web push is not configured on this server.", true);
@@ -139,20 +154,26 @@
     }
 
     async function unsubscribePush() {
-      const registration = await getRegistration();
-      const subscription = await registration.pushManager.getSubscription();
-      if (!subscription) {
+      const subscriptions = await getAllLocalSubscriptions();
+      if (!subscriptions.length) {
         updateStatus("No active browser push subscription found.");
         return;
       }
 
-      const data = subscription.toJSON();
-      await fetch("/api/v1/notifications/web-push/unsubscribe", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ endpoint: data.endpoint }),
-      });
-      await subscription.unsubscribe();
+      const seenEndpoints = new Set();
+      for (const { subscription } of subscriptions) {
+        const data = subscription.toJSON();
+        if (data.endpoint && !seenEndpoints.has(data.endpoint)) {
+          seenEndpoints.add(data.endpoint);
+          await fetch("/api/v1/notifications/web-push/unsubscribe", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ endpoint: data.endpoint }),
+          });
+        }
+        await subscription.unsubscribe();
+      }
+
       pushCount.textContent = "0";
       updateStatus("Browser push notifications are disabled.");
     }


### PR DESCRIPTION
## Summary
- fix Disable browser push flow after service-worker scope migration
- unsubscribe from all local service-worker push subscriptions (legacy and new scope)
- call unsubscribe API for each unique endpoint found locally

## Why
After moving push worker scope to `/notifications/`, users with old root-scope subscriptions could see:
- "Active browser subscriptions: 1"
- clicking Disable -> "No active browser push subscription found"

This patch resolves that mismatch.

## Validation
- `.venv/bin/pytest -q tests/test_digest_routes_api.py tests/test_digest_notifications.py`
- result: `8 passed`
