### PR TITLE
Notifications: single settings destination + preferred digest email

### DIFF
--- a/alembic/versions/20260215_04_notification_email_preferences.py
+++ b/alembic/versions/20260215_04_notification_email_preferences.py
@@ -1,0 +1,65 @@
+"""add notification email preference fields
+
+Revision ID: 20260215_04
+Revises: 20260214_03
+Create Date: 2026-02-15 11:20:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260215_04"
+down_revision: Union[str, None] = "20260214_03"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+
+    if "notification_preferences" not in table_names:
+        return
+
+    existing_columns = {
+        column["name"] for column in inspector.get_columns("notification_preferences")
+    }
+
+    with op.batch_alter_table("notification_preferences", schema=None) as batch_op:
+        if "use_account_email_for_notifications" not in existing_columns:
+            batch_op.add_column(
+                sa.Column(
+                    "use_account_email_for_notifications",
+                    sa.Boolean(),
+                    nullable=False,
+                    server_default=sa.true(),
+                )
+            )
+        if "notification_email" not in existing_columns:
+            batch_op.add_column(
+                sa.Column("notification_email", sa.String(length=255), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+    if "notification_preferences" not in table_names:
+        return
+
+    existing_columns = {
+        column["name"] for column in inspector.get_columns("notification_preferences")
+    }
+
+    with op.batch_alter_table("notification_preferences", schema=None) as batch_op:
+        if "notification_email" in existing_columns:
+            batch_op.drop_column("notification_email")
+        if "use_account_email_for_notifications" in existing_columns:
+            batch_op.drop_column("use_account_email_for_notifications")

--- a/app/blueprints/auth/wrappers.py
+++ b/app/blueprints/auth/wrappers.py
@@ -56,7 +56,7 @@ def login_required(next_page: str = "awards.qsls"):
     return decorator
 
 
-def paid_required(next_page: str = "billing.overview"):
+def paid_required(next_page: str = "billing.notification_settings"):
     def decorator(view):
         @wraps(view)
         def decorated_view(*args, **kwargs):
@@ -85,7 +85,10 @@ def paid_required(next_page: str = "billing.overview"):
                     flash("An active subscription is required for this feature.", "warning")
                     return redirect(
                         url_for(
-                            sanitize_next_page(next_page=next_page, default="billing.overview")
+                            sanitize_next_page(
+                                next_page=next_page,
+                                default="billing.notification_settings",
+                            )
                         )
                     )
             return view(*args, **kwargs)

--- a/app/blueprints/billing/__init__.py
+++ b/app/blueprints/billing/__init__.py
@@ -1,3 +1,8 @@
 from .base import bp
 from .notifications import notification_settings
-from .overview import create_checkout_session, overview, stripe_webhook
+from .overview import (
+    create_checkout_session,
+    create_portal_session,
+    overview,
+    stripe_webhook,
+)

--- a/app/blueprints/billing/notifications.py
+++ b/app/blueprints/billing/notifications.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from flask import (
@@ -15,8 +16,9 @@ from ...database.queries import (
     get_active_web_push_subscriptions,
     get_user,
 )
-from ..auth.wrappers import login_required, paid_required
+from ..auth.wrappers import login_required
 from .base import bp
+from .overview import _stripe_price_options, _stripe_ready
 
 TIMEZONE_OPTIONS: tuple[tuple[str, str], ...] = (
     ("UTC", "UTC"),
@@ -38,6 +40,9 @@ TIMEZONE_OPTIONS: tuple[tuple[str, str], ...] = (
 )
 
 
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
 def _is_valid_timezone(tz_name: str) -> bool:
     try:
         ZoneInfo(tz_name)
@@ -46,37 +51,99 @@ def _is_valid_timezone(tz_name: str) -> bool:
         return False
 
 
+def _is_valid_email(value: str) -> bool:
+    return bool(EMAIL_PATTERN.match(value))
+
+
 @bp.route("/notifications/settings", methods=["GET", "POST"])
 @login_required()
-@paid_required(next_page="billing.overview")
 def notification_settings():
+    checkout_state = request.args.get("checkout", type=str, default="").strip().lower()
+    if checkout_state == "success":
+        flash("Subscription checkout completed. Refreshing plan status may take a moment.", "success")
+    elif checkout_state == "cancel":
+        flash("Checkout was canceled.", "info")
+
     with current_app.config.get("SESSION_MAKER").begin() as session_:
         user = get_user(op=session.get("op"), session=session_)
         preference = ensure_notification_preference(user=user, session=session_)
+        has_paid_access = user.has_active_entitlement
+        stripe_ready = bool(current_app.config.get("BILLING_UI_ENABLED", False)) and _stripe_ready()
+        price_options = _stripe_price_options()
 
         if request.method == "POST":
-            timezone_input = request.form.get("timezone", type=str, default="").strip()
-            if timezone_input and _is_valid_timezone(timezone_input):
-                user.timezone = timezone_input
-            elif timezone_input:
-                flash("Invalid timezone. Use an IANA timezone like America/Chicago.", "error")
+            if not has_paid_access:
+                flash(
+                    "An active subscription is required to change notification settings.",
+                    "warning",
+                )
+            else:
+                has_error = False
+                timezone_input = request.form.get(
+                    "timezone",
+                    type=str,
+                    default="",
+                ).strip()
+                if timezone_input and _is_valid_timezone(timezone_input):
+                    user.timezone = timezone_input
+                elif timezone_input:
+                    flash(
+                        "Invalid timezone. Use an IANA timezone like America/Chicago.",
+                        "error",
+                    )
+                    has_error = True
 
-            locale_input = request.form.get("locale", type=str, default="").strip()
-            user.locale = locale_input or None
+                locale_input = request.form.get("locale", type=str, default="").strip()
+                user.locale = locale_input or None
 
-            time_input = request.form.get("qsl_digest_time_local", type=str, default="")
-            if time_input:
-                try:
-                    preference.qsl_digest_time_local = datetime.strptime(
-                        time_input, "%H:%M"
-                    ).time()
-                except ValueError:
-                    flash("Invalid digest time. Use HH:MM format.", "error")
+                time_input = request.form.get("qsl_digest_time_local", type=str, default="")
+                if time_input:
+                    try:
+                        preference.qsl_digest_time_local = datetime.strptime(
+                            time_input, "%H:%M"
+                        ).time()
+                    except ValueError:
+                        flash("Invalid digest time. Use HH:MM format.", "error")
+                        has_error = True
 
-            preference.qsl_digest_enabled = bool(request.form.get("qsl_digest_enabled"))
-            preference.fallback_to_email = bool(request.form.get("fallback_to_email"))
+                preference.qsl_digest_enabled = bool(
+                    request.form.get("qsl_digest_enabled")
+                )
+                preference.fallback_to_email = bool(
+                    request.form.get("fallback_to_email")
+                )
 
-            flash("Notification settings saved.", "success")
+                use_account_email = bool(
+                    request.form.get("use_account_email_for_notifications")
+                )
+                preference.use_account_email_for_notifications = use_account_email
+                notification_email = request.form.get(
+                    "notification_email",
+                    type=str,
+                    default="",
+                ).strip()
+
+                if notification_email and not _is_valid_email(notification_email):
+                    flash("Notification email is invalid.", "error")
+                    has_error = True
+                elif use_account_email:
+                    preference.notification_email = None
+                else:
+                    preference.notification_email = notification_email or None
+
+                if (
+                    preference.fallback_to_email
+                    and not preference.notification_email
+                    and not (user.email or "").strip()
+                    and preference.use_account_email_for_notifications
+                ):
+                    flash(
+                        "Fallback email is enabled, but your account email is empty.",
+                        "warning",
+                    )
+
+                if not has_error:
+                    flash("Notification settings saved.", "success")
 
         active_subscriptions = get_active_web_push_subscriptions(
             user_id=user.id, session=session_
@@ -96,4 +163,14 @@ def notification_settings():
             active_web_push_count=len(active_subscriptions),
             user_op=user.op,
             settings_url=url_for("billing.notification_settings"),
+            has_paid_access=has_paid_access,
+            stripe_ready=stripe_ready,
+            price_options=price_options,
+            can_manage_subscription=bool(user.stripe_customer_id) and stripe_ready,
+            subscription={
+                "tier": user.plan_tier,
+                "status": user.subscription_status,
+                "current_period_end": user.subscription_current_period_end,
+                "entitlement_expires_at": user.entitlement_expires_at,
+            },
         )

--- a/app/database/table_declarations/notification_preference.py
+++ b/app/database/table_declarations/notification_preference.py
@@ -31,6 +31,11 @@ class NotificationPreference(Base):
         default="daily",
     )
     fallback_to_email: Mapped[bool] = mapped_column(default=True)
+    use_account_email_for_notifications: Mapped[bool] = mapped_column(default=True)
+    notification_email: Mapped[str | None] = mapped_column(
+        String(length=255),
+        nullable=True,
+    )
     quiet_hours_start_local: Mapped[time | None] = mapped_column(
         Time(),
         nullable=True,

--- a/app/services/digest_email.py
+++ b/app/services/digest_email.py
@@ -38,9 +38,11 @@ def send_qsl_digest_email(
     user: User,
     batch: QSLDigestBatch,
     digest_url: str,
+    recipient_email: str | None = None,
     send_callable=None,
 ) -> str:
-    if not user.email:
+    to_email = (recipient_email or user.email or "").strip()
+    if not to_email:
         raise DigestEmailSendError("missing_recipient_email")
 
     sender = send_callable or _default_send_callable
@@ -49,7 +51,7 @@ def send_qsl_digest_email(
     msg = EmailMessage()
     msg["Subject"] = f"Daily QSL Digest: {batch.qsl_count} new QSLs"
     msg["From"] = from_email
-    msg["To"] = user.email
+    msg["To"] = to_email
     msg["Date"] = datetime.now(tz=timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
     msg.set_content(
         "\n".join(

--- a/app/templates/components/navbar.html
+++ b/app/templates/components/navbar.html
@@ -48,17 +48,14 @@
           </li>
 
           <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('map.view') }}"
-            >QSL Map <!--// i class="fa-solid fa-location-dot"></i
+            <a class="nav-link" href="{{ url_for('map.view') }}"
+              >QSL Map <!--// i class="fa-solid fa-location-dot"></i
           //--></a>
         </li>
           <li class="nav-item">
             <a class="nav-link" href="{{ url_for('billing.notification_settings') }}"
-              >Alerts</a>
+              >Notifications</a>
           </li>
-          {% if config.get('BILLING_UI_ENABLED', False) %}
-            <li class="nav-item"><a class="nav-link" href="{{ url_for('billing.overview') }}">Notifications</a></li>
-          {% endif %}
         {% endif %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('about') }}">About</a></li>
         {% if not session.logged_in %}

--- a/app/templates/notification_settings.html
+++ b/app/templates/notification_settings.html
@@ -1,80 +1,176 @@
 {% extends "index.html" %}
 
 {% block content %}
-  <form method="post" action="{{ settings_url }}" class="text-start mx-auto" style="max-width: 640px">
-    <div class="mb-3 form-check">
-      <input
-        class="form-check-input"
-        type="checkbox"
-        id="qsl_digest_enabled"
-        name="qsl_digest_enabled"
-        {% if preference.qsl_digest_enabled %}checked{% endif %}
-      />
-      <label class="form-check-label" for="qsl_digest_enabled">Enable daily QSL digest notifications</label>
-    </div>
-
-    <div class="mb-3">
-      <label for="qsl_digest_time_local" class="form-label">Digest send time (local)</label>
-      <input
-        class="form-control"
-        type="time"
-        id="qsl_digest_time_local"
-        name="qsl_digest_time_local"
-        value="{{ preference.qsl_digest_time_local.strftime('%H:%M') }}"
-      />
-    </div>
-
-    <div class="mb-3">
-      <label for="timezone" class="form-label">Timezone (IANA)</label>
-      <select class="form-select" id="timezone" name="timezone">
-        {% for timezone_value, timezone_label in timezone_options %}
-          <option value="{{ timezone_value }}" {% if (user.timezone or "UTC") == timezone_value %}selected{% endif %}>
-            {{ timezone_label }}
-          </option>
-        {% endfor %}
-      </select>
-      <div class="form-text">Choose the timezone used for your daily digest send time.</div>
-    </div>
-
-    <div class="mb-3">
-      <label for="locale" class="form-label">Locale (optional)</label>
-      <input class="form-control" type="text" id="locale" name="locale" value="{{ user.locale or '' }}" />
-    </div>
-
-    <div class="mb-3 form-check">
-      <input
-        class="form-check-input"
-        type="checkbox"
-        id="fallback_to_email"
-        name="fallback_to_email"
-        {% if preference.fallback_to_email %}checked{% endif %}
-      />
-      <label class="form-check-label" for="fallback_to_email">Fallback to email when web push is unavailable</label>
-    </div>
-
-    <button type="submit" class="btn btn-primary">Save settings</button>
-  </form>
-
-  <hr class="my-4" />
-
-  <div class="text-start mx-auto" style="max-width: 640px">
-    <h4>Web Push</h4>
-    <p>
-      Active browser subscriptions: <strong id="push-count">{{ active_web_push_count }}</strong>
+  <div class="text-start mx-auto" style="max-width: 720px">
+    <h2 class="mb-3">Notifications</h2>
+    <p class="text-muted">
+      Daily digest status:
+      <strong>{{ subscription.tier|upper }}</strong>
+      {% if subscription.status %}
+        <span class="ms-1">({{ subscription.status }})</span>
+      {% endif %}
     </p>
-    <button id="enable-push-btn" class="btn btn-success me-2" type="button">Enable browser push</button>
-    <button id="disable-push-btn" class="btn btn-outline-secondary" type="button">Disable browser push</button>
-    <p class="mt-3 mb-0"><small id="push-status"></small></p>
+
+    {% if not has_paid_access %}
+      <div class="alert alert-warning" role="alert">
+        Notification delivery is part of the paid plan. Subscribe below to unlock settings.
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title mb-3">Subscribe To Notifications</h5>
+          {% if stripe_ready %}
+            <div class="mb-3">
+              <label for="billing-email" class="form-label">Billing email (optional)</label>
+              <input
+                class="form-control"
+                id="billing-email"
+                type="email"
+                value="{{ user.email or '' }}"
+                placeholder="you@example.com"
+              />
+              <div class="form-text">Used for Stripe checkout receipts and account billing.</div>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Choose plan</label>
+              {% if price_options.get("monthly") %}
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="billing-plan" id="billing-plan-monthly" value="monthly" checked />
+                  <label class="form-check-label" for="billing-plan-monthly">Monthly</label>
+                </div>
+              {% endif %}
+              {% if price_options.get("annual") %}
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="billing-plan" id="billing-plan-annual" value="annual" {% if not price_options.get("monthly") %}checked{% endif %} />
+                  <label class="form-check-label" for="billing-plan-annual">Annual</label>
+                </div>
+              {% endif %}
+            </div>
+            <button id="start-checkout" class="btn btn-primary" type="button">Start Subscription</button>
+            <small id="billing-status" class="d-block mt-3"></small>
+          {% else %}
+            <p class="mb-0">Billing is not configured on this server yet.</p>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+
+    <form method="post" action="{{ settings_url }}" id="notification-settings-form">
+      <fieldset {% if not has_paid_access %}disabled{% endif %}>
+        <div class="mb-3 form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="qsl_digest_enabled"
+            name="qsl_digest_enabled"
+            {% if preference.qsl_digest_enabled %}checked{% endif %}
+          />
+          <label class="form-check-label" for="qsl_digest_enabled">Enable daily QSL digest notifications</label>
+        </div>
+
+        <div class="mb-3">
+          <label for="qsl_digest_time_local" class="form-label">Digest send time (local)</label>
+          <input
+            class="form-control"
+            type="time"
+            id="qsl_digest_time_local"
+            name="qsl_digest_time_local"
+            value="{{ preference.qsl_digest_time_local.strftime('%H:%M') }}"
+          />
+        </div>
+
+        <div class="mb-3">
+          <label for="timezone" class="form-label">Timezone</label>
+          <select class="form-select" id="timezone" name="timezone">
+            {% for timezone_value, timezone_label in timezone_options %}
+              <option value="{{ timezone_value }}" {% if (user.timezone or "UTC") == timezone_value %}selected{% endif %}>
+                {{ timezone_label }}
+              </option>
+            {% endfor %}
+          </select>
+          <div class="form-text">Choose the timezone used for your daily digest send time.</div>
+        </div>
+
+        <div class="mb-3">
+          <label for="locale" class="form-label">Locale (optional)</label>
+          <input class="form-control" type="text" id="locale" name="locale" value="{{ user.locale or '' }}" />
+        </div>
+
+        <div class="mb-3 form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="fallback_to_email"
+            name="fallback_to_email"
+            {% if preference.fallback_to_email %}checked{% endif %}
+          />
+          <label class="form-check-label" for="fallback_to_email">Fallback to email when web push is unavailable</label>
+        </div>
+
+        <div class="mb-3 form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="use_account_email_for_notifications"
+            name="use_account_email_for_notifications"
+            {% if preference.use_account_email_for_notifications %}checked{% endif %}
+          />
+          <label class="form-check-label" for="use_account_email_for_notifications">Use account email for notification fallback</label>
+        </div>
+
+        <div class="mb-4">
+          <label for="notification_email" class="form-label">Preferred notification email</label>
+          <input
+            class="form-control"
+            type="email"
+            id="notification_email"
+            name="notification_email"
+            value="{{ preference.notification_email or '' }}"
+            placeholder="alerts@example.com"
+          />
+          <div class="form-text">Leave blank to disable email fallback when push fails.</div>
+        </div>
+
+        <button type="submit" class="btn btn-primary">Save settings</button>
+      </fieldset>
+    </form>
+
+    {% if has_paid_access %}
+      <hr class="my-4" />
+      <div>
+        <h4>Web Push</h4>
+        <p>
+          Active browser subscriptions: <strong id="push-count">{{ active_web_push_count }}</strong>
+        </p>
+        <button id="enable-push-btn" class="btn btn-success me-2" type="button">Enable browser push</button>
+        <button id="disable-push-btn" class="btn btn-outline-secondary" type="button">Disable browser push</button>
+        <p class="mt-3 mb-0"><small id="push-status"></small></p>
+      </div>
+
+      {% if can_manage_subscription %}
+        <hr class="my-4" />
+        <div>
+          <h4>Subscription</h4>
+          <button id="manage-subscription-btn" class="btn btn-outline-secondary" type="button">Manage subscription</button>
+          <p class="mb-0 mt-2"><small id="manage-subscription-status"></small></p>
+        </div>
+      {% endif %}
+    {% endif %}
   </div>
 {% endblock %}
 
 {% block scripts %}
   <script>
+    const hasPaidAccess = {{ "true" if has_paid_access else "false" }};
     const pushStatus = document.getElementById("push-status");
     const pushCount = document.getElementById("push-count");
     const publicVapidKey = "{{ web_push_public_key }}";
 
     function updateStatus(message, isError = false) {
+      if (!pushStatus) {
+        return;
+      }
       pushStatus.textContent = message;
       pushStatus.style.color = isError ? "#b00020" : "inherit";
     }
@@ -178,20 +274,111 @@
       updateStatus("Browser push notifications are disabled.");
     }
 
-    document.getElementById("enable-push-btn").addEventListener("click", async () => {
-      try {
-        await subscribePush();
-      } catch (error) {
-        updateStatus(error.message || "Unable to enable push notifications.", true);
+    function wireCheckout() {
+      const checkoutButton = document.getElementById("start-checkout");
+      if (!checkoutButton) {
+        return;
       }
-    });
+      const billingStatus = document.getElementById("billing-status");
+      checkoutButton.addEventListener("click", async () => {
+        const selectedPlan = document.querySelector('input[name="billing-plan"]:checked')?.value || "monthly";
+        const emailInput = document.getElementById("billing-email");
+        const email = emailInput?.value?.trim() || "";
+        checkoutButton.disabled = true;
+        if (billingStatus) {
+          billingStatus.textContent = "Starting checkout...";
+        }
+        try {
+          const response = await fetch("{{ url_for('billing.create_checkout_session') }}", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ plan: selectedPlan, email, source: "notifications_settings" }),
+          });
+          if (!response.ok) {
+            throw new Error("Unable to start checkout right now.");
+          }
+          const data = await response.json();
+          if (!data.checkout_url) {
+            throw new Error("Checkout session did not return a URL.");
+          }
+          window.location.href = data.checkout_url;
+        } catch (error) {
+          if (billingStatus) {
+            billingStatus.textContent = error.message || "Unable to start checkout.";
+            billingStatus.style.color = "#b00020";
+          }
+          checkoutButton.disabled = false;
+        }
+      });
+    }
 
-    document.getElementById("disable-push-btn").addEventListener("click", async () => {
-      try {
-        await unsubscribePush();
-      } catch (error) {
-        updateStatus(error.message || "Unable to disable push notifications.", true);
+    function wireSubscriptionPortal() {
+      const manageButton = document.getElementById("manage-subscription-btn");
+      if (!manageButton) {
+        return;
       }
-    });
+      const statusEl = document.getElementById("manage-subscription-status");
+      manageButton.addEventListener("click", async () => {
+        manageButton.disabled = true;
+        if (statusEl) {
+          statusEl.textContent = "Opening customer portal...";
+        }
+        try {
+          const response = await fetch("{{ url_for('billing.create_portal_session') }}", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          });
+          if (!response.ok) {
+            throw new Error("Unable to open billing portal.");
+          }
+          const data = await response.json();
+          if (!data.portal_url) {
+            throw new Error("Billing portal did not return a URL.");
+          }
+          window.location.href = data.portal_url;
+        } catch (error) {
+          if (statusEl) {
+            statusEl.textContent = error.message || "Unable to open billing portal.";
+            statusEl.style.color = "#b00020";
+          }
+          manageButton.disabled = false;
+        }
+      });
+    }
+
+    function wireNotificationEmailToggle() {
+      const useAccountEmail = document.getElementById("use_account_email_for_notifications");
+      const customEmail = document.getElementById("notification_email");
+      if (!useAccountEmail || !customEmail) {
+        return;
+      }
+      const updateState = () => {
+        customEmail.disabled = useAccountEmail.checked;
+      };
+      useAccountEmail.addEventListener("change", updateState);
+      updateState();
+    }
+
+    if (hasPaidAccess) {
+      document.getElementById("enable-push-btn")?.addEventListener("click", async () => {
+        try {
+          await subscribePush();
+        } catch (error) {
+          updateStatus(error.message || "Unable to enable push notifications.", true);
+        }
+      });
+
+      document.getElementById("disable-push-btn")?.addEventListener("click", async () => {
+        try {
+          await unsubscribePush();
+        } catch (error) {
+          updateStatus(error.message || "Unable to disable push notifications.", true);
+        }
+      });
+    }
+
+    wireCheckout();
+    wireSubscriptionPortal();
+    wireNotificationEmailToggle();
   </script>
 {% endblock %}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -150,12 +150,15 @@ os.environ['DEPLOY_ALLOWED_IPS'] = "127.0.0.1,10.0.0.1"
 os.environ['DEPLOY_SCRIPT_PATH'] = "/path/to/your/deploy/script"
 
 # Optional Stripe settings for billing/subscriptions.
+os.environ['BILLING_UI_ENABLED'] = "1"
 os.environ['STRIPE_SECRET_KEY'] = "REPLACE_ME_NOW"
 os.environ['STRIPE_WEBHOOK_SECRET'] = "REPLACE_ME_NOW"
 os.environ['STRIPE_PRICE_ID_MONTHLY'] = "price_REPLACE_ME"
 os.environ['STRIPE_PRICE_ID_ANNUAL'] = "price_REPLACE_ME"
 # Optional backward-compatible fallback if monthly key is not set:
 os.environ['STRIPE_PRICE_ID'] = "price_REPLACE_ME"
+# Optional return URL after Stripe billing-portal management.
+os.environ['STRIPE_PORTAL_RETURN_URL'] = "https://mobilelotw.org/notifications/settings"
 
 # QSL digest notification controls.
 os.environ['DIGEST_NOTIFICATIONS_ENABLED'] = "1"
@@ -190,12 +193,18 @@ Run Alembic migrations after deployment changes that add columns or tables:
 alembic upgrade head
 ```
 
+Current notification/billing rollout requires at least:
+- `20260214_03_qsl_digest_notification_foundation.py`
+- `20260215_04_notification_email_preferences.py`
+
 ### QSL digest production verification
 
 After deployment and migration:
-1. Verify `/notifications/settings` loads for a paid user.
+1. Verify `/notifications/settings` is the single notifications destination:
+   - free user sees locked settings and inline billing options
+   - paid user sees editable settings (including preferred notification email)
 2. Verify `/qsl/digest?date=YYYY-MM-DD` returns a digest page.
-3. Verify browser push subscription API works:
+3. Verify browser push subscription API works for paid users:
    - `POST /api/v1/notifications/web-push/subscribe`
    - `POST /api/v1/notifications/web-push/unsubscribe`
 4. Run one digest generation cycle and confirm rows in:

--- a/example.env
+++ b/example.env
@@ -27,12 +27,15 @@ DEPLOY_WEBHOOK_SECRET = "REPLACE ME"
 DEPLOY_ALLOWED_IPS = ""
 
 # Stripe billing settings (optional until billing launch).
+BILLING_UI_ENABLED = 1
 STRIPE_SECRET_KEY = "REPLACE ME"
 STRIPE_WEBHOOK_SECRET = "REPLACE ME"
 STRIPE_PRICE_ID_MONTHLY = "REPLACE ME"
 STRIPE_PRICE_ID_ANNUAL = "REPLACE ME"
 # Backwards compatibility fallback if monthly env var is not set.
 STRIPE_PRICE_ID = ""
+# Optional: where Stripe billing portal returns users.
+STRIPE_PORTAL_RETURN_URL = "https://mobilelotw.org/notifications/settings"
 
 # QSL digest notifications feature flags.
 DIGEST_NOTIFICATIONS_ENABLED = 1

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -208,10 +208,10 @@ class SubscriptionGateTests(unittest.TestCase):
         payload = response.get_json()
         self.assertEqual(payload["error"], "subscription_required")
 
-    def test_paid_web_route_redirects_to_billing_when_subscription_required(self):
+    def test_paid_web_route_redirects_to_notifications_when_subscription_required(self):
         response = self.client.get("/map", follow_redirects=False)
         self.assertEqual(response.status_code, 302)
-        self.assertIn("/billing", response.headers["Location"])
+        self.assertIn("/notifications/settings", response.headers["Location"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- make /notifications/settings the single destination for notifications and billing UX
- show inline checkout for free users and editable settings for paid users
- add preferred notification email fields to notification_preferences
- add Stripe customer portal endpoint for subscription management
- route digest email fallback to preferred notification email when configured
- update navbar and /billing behavior to direct users to notifications settings
- update docs/runbooks and add migration for notification email fields

Testing:
- python3 -m compileall app/blueprints/billing app/services app/database/table_declarations tests
- .venv/bin/pytest -q