### PR TITLE
Digest scaling: pending-only dispatch, retention cleanup, scheduler script

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,6 +99,7 @@ def create_app() -> Flask:
         WEB_PUSH_ENABLED=_env_flag("WEB_PUSH_ENABLED", True),
         DIGEST_EMAIL_ENABLED=_env_flag("DIGEST_EMAIL_ENABLED", True),
         DIGEST_DRY_RUN=_env_flag("DIGEST_DRY_RUN", False),
+        DIGEST_RETENTION_DAYS=int(getenv("DIGEST_RETENTION_DAYS", "90")),
     )
 
     # Logging level

--- a/docs/qsl_digest_notifications_plan.md
+++ b/docs/qsl_digest_notifications_plan.md
@@ -335,6 +335,7 @@ Add env flags:
 - `WEB_PUSH_ENABLED`
 - `DIGEST_EMAIL_ENABLED`
 - `DIGEST_DRY_RUN` (logs intended sends without sending)
+- `DIGEST_RETENTION_DAYS` (delete old digest snapshots + deliveries)
 
 ### 6.3 Admin/debug tooling (lightweight)
 
@@ -415,6 +416,7 @@ Required for this feature:
 - `WEB_PUSH_ENABLED`
 - `DIGEST_EMAIL_ENABLED`
 - `DIGEST_DRY_RUN`
+- `DIGEST_RETENTION_DAYS`
 - `WEB_PUSH_VAPID_PUBLIC_KEY`
 - `WEB_PUSH_VAPID_PRIVATE_KEY`
 - `WEB_PUSH_VAPID_SUBJECT`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -165,6 +165,7 @@ os.environ['DIGEST_NOTIFICATIONS_ENABLED'] = "1"
 os.environ['WEB_PUSH_ENABLED'] = "1"
 os.environ['DIGEST_EMAIL_ENABLED'] = "1"
 os.environ['DIGEST_DRY_RUN'] = "0"
+os.environ['DIGEST_RETENTION_DAYS'] = "90"
 
 # Web push VAPID settings.
 os.environ['WEB_PUSH_VAPID_PUBLIC_KEY'] = "REPLACE_ME_NOW"
@@ -210,6 +211,14 @@ After deployment and migration:
 4. Run one digest generation cycle and confirm rows in:
    - `qsl_digest_batches`
    - `notification_deliveries`
+
+### Scheduled digest runner (recommended)
+
+Run the tracked runner script on a schedule (for example every 15 minutes):
+
+```cron
+*/15 * * * * /usr/bin/flock -n /tmp/mobile_lotw_digest.lock /var/www/mobile_lotw/mobile_lotw/.venv/bin/python /var/www/mobile_lotw/mobile_lotw/scripts/run_digest_cycle.py >> /var/www/mobile_lotw/mobile_lotw/logs/digest_runner.log 2>&1
+```
 
 ### Deploy endpoint hardening
 

--- a/example.env
+++ b/example.env
@@ -42,6 +42,8 @@ DIGEST_NOTIFICATIONS_ENABLED = 1
 WEB_PUSH_ENABLED = 1
 DIGEST_EMAIL_ENABLED = 1
 DIGEST_DRY_RUN = 0
+# Retain digest batches/deliveries for N days (0 disables cleanup).
+DIGEST_RETENTION_DAYS = 90
 
 # Web push (VAPID) settings.
 WEB_PUSH_VAPID_PUBLIC_KEY = ""

--- a/scripts/run_digest_cycle.py
+++ b/scripts/run_digest_cycle.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+from dotenv import load_dotenv
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+load_dotenv(ROOT / ".env")
+
+from app import create_app
+from app.services.digest_notifications import dispatch_pending_digest_notifications
+from app.services.qsl_digest import run_due_qsl_digest_generation
+
+app = create_app()
+
+with app.app_context():
+    generation = run_due_qsl_digest_generation()
+    dispatch = dispatch_pending_digest_notifications(limit=10_000)
+    print("generation:", generation)
+    print("dispatch:", dispatch)


### PR DESCRIPTION
Summary:
- dispatch only truly pending digest batches (skip batches already marked sent)
- add retention cleanup for old qsl_digest_batches and notification_deliveries
- add DIGEST_RETENTION_DAYS config (default 90)
- add tracked scheduler runner script at scripts/run_digest_cycle.py
- document cron setup and retention env var
- add tests for pending-only dispatch and retention cleanup

Validation:
- python3 -m compileall app/services app/__init__.py scripts tests/test_digest_notifications.py
- .venv/bin/pytest -q (34 passed)
